### PR TITLE
Mouse event improvements

### DIFF
--- a/src/qt/qt_rendererstack.cpp
+++ b/src/qt/qt_rendererstack.cpp
@@ -103,7 +103,7 @@ void RendererStack::wheelEvent(QWheelEvent *event)
     }
 }
 
-int ignoreNextMouseEvent = 0;
+int ignoreNextMouseEvent = 1;
 void RendererStack::mouseMoveEvent(QMouseEvent *event)
 {
     if (QApplication::platformName().contains("wayland"))
@@ -120,10 +120,21 @@ void RendererStack::mouseMoveEvent(QMouseEvent *event)
     if (ignoreNextMouseEvent) { oldPos = event->pos(); ignoreNextMouseEvent--; event->accept(); return; }
     mousedata.deltax += event->pos().x() - oldPos.x();
     mousedata.deltay += event->pos().y() - oldPos.y();
-    QCursor::setPos(mapToGlobal(QPoint(width() / 2, height() / 2)));
     oldPos = event->pos();
-    ignoreNextMouseEvent = 1;
 #endif
+}
+
+void RendererStack::leaveEvent(QEvent* event)
+{
+    if (QApplication::platformName().contains("wayland"))
+    {
+        event->accept();
+        return;
+    }
+    if (!mouse_capture) return;
+    QCursor::setPos(mapToGlobal(QPoint(width() / 2, height() / 2)));
+    ignoreNextMouseEvent = 2;
+    event->accept();
 }
 
 // called from blitter thread

--- a/src/qt/qt_rendererstack.cpp
+++ b/src/qt/qt_rendererstack.cpp
@@ -4,6 +4,8 @@
 #include "qt_softwarerenderer.hpp"
 #include "qt_hardwarerenderer.hpp"
 
+#include <QScreen>
+
 #ifdef __APPLE__
 #include <CoreGraphics/CoreGraphics.h>
 #endif
@@ -120,6 +122,8 @@ void RendererStack::mouseMoveEvent(QMouseEvent *event)
     if (ignoreNextMouseEvent) { oldPos = event->pos(); ignoreNextMouseEvent--; event->accept(); return; }
     mousedata.deltax += event->pos().x() - oldPos.x();
     mousedata.deltay += event->pos().y() - oldPos.y();
+    if (event->pos().x() == 0 || event->pos().y() == 0) leaveEvent((QEvent*)event);
+    if (event->pos().x() == screen()->geometry().width() || event->pos().y() == screen()->geometry().height()) leaveEvent((QEvent*)event);
     oldPos = event->pos();
 #endif
 }

--- a/src/qt/qt_rendererstack.cpp
+++ b/src/qt/qt_rendererstack.cpp
@@ -123,7 +123,7 @@ void RendererStack::mouseMoveEvent(QMouseEvent *event)
     mousedata.deltax += event->pos().x() - oldPos.x();
     mousedata.deltay += event->pos().y() - oldPos.y();
     if (event->globalPos().x() == 0 || event->globalPos().y() == 0) leaveEvent((QEvent*)event);
-    if (event->globalPos().x() == screen()->geometry().width() || event->globalPos().y() == screen()->geometry().height()) leaveEvent((QEvent*)event);
+    if (event->globalPos().x() == (screen()->geometry().width() - 1) || event->globalPos().y() == (screen()->geometry().height() - 1)) leaveEvent((QEvent*)event);
     oldPos = event->pos();
 #endif
 }

--- a/src/qt/qt_rendererstack.cpp
+++ b/src/qt/qt_rendererstack.cpp
@@ -122,8 +122,8 @@ void RendererStack::mouseMoveEvent(QMouseEvent *event)
     if (ignoreNextMouseEvent) { oldPos = event->pos(); ignoreNextMouseEvent--; event->accept(); return; }
     mousedata.deltax += event->pos().x() - oldPos.x();
     mousedata.deltay += event->pos().y() - oldPos.y();
-    if (event->pos().x() == 0 || event->pos().y() == 0) leaveEvent((QEvent*)event);
-    if (event->pos().x() == screen()->geometry().width() || event->pos().y() == screen()->geometry().height()) leaveEvent((QEvent*)event);
+    if (event->globalPos().x() == 0 || event->globalPos().y() == 0) leaveEvent((QEvent*)event);
+    if (event->globalPos().x() == screen()->geometry().width() || event->globalPos().y() == screen()->geometry().height()) leaveEvent((QEvent*)event);
     oldPos = event->pos();
 #endif
 }

--- a/src/qt/qt_rendererstack.hpp
+++ b/src/qt/qt_rendererstack.hpp
@@ -3,6 +3,7 @@
 
 #include <QStackedWidget>
 #include <QKeyEvent>
+#include <QEvent>
 
 namespace Ui {
 class RendererStack;
@@ -20,6 +21,7 @@ public:
     void mouseReleaseEvent(QMouseEvent* event) override;
     void mouseMoveEvent(QMouseEvent* event) override;
     void wheelEvent(QWheelEvent *event) override;
+    void leaveEvent(QEvent *event) override;
     void keyPressEvent(QKeyEvent* event) override
     {
         event->ignore();


### PR DESCRIPTION
* Only center the cursor when it leaves the emulator screen
* Ignore the very first mouse event that appears after it is captured for the first time after starting