### PR TITLE
Status bar improvements

### DIFF
--- a/src/qt/qt_machinestatus.cpp
+++ b/src/qt/qt_machinestatus.cpp
@@ -452,7 +452,7 @@ void MachineStatus::refresh(QStatusBar* sbar) {
     d->sound = std::make_unique<ClickableLabel>();
     d->sound->setPixmap(d->pixmaps.sound);
     // Triggering on click makes the mouse move the window when the button is releases. Do it on button release instead.
-    connect(d->sound.get(), &ClickableLabel::clickedRelease, d->sound.get(), [this](QPoint pos) {
+    connect(d->sound.get(), &ClickableLabel::doubleClicked, d->sound.get(), [this](QPoint pos) {
         SoundGain gain(main_window);
         gain.exec();
     });

--- a/src/qt/qt_machinestatus.cpp
+++ b/src/qt/qt_machinestatus.cpp
@@ -451,7 +451,7 @@ void MachineStatus::refresh(QStatusBar* sbar) {
     }
     d->sound = std::make_unique<ClickableLabel>();
     d->sound->setPixmap(d->pixmaps.sound);
-    // Triggering on click makes the mouse move the window when the button is releases. Do it on button release instead.
+
     connect(d->sound.get(), &ClickableLabel::doubleClicked, d->sound.get(), [this](QPoint pos) {
         SoundGain gain(main_window);
         gain.exec();

--- a/src/qt/qt_machinestatus.cpp
+++ b/src/qt/qt_machinestatus.cpp
@@ -411,25 +411,25 @@ void MachineStatus::refresh(QStatusBar* sbar) {
     });
 
     auto hdc_name = QString(hdc_get_internal_name(hdc_current));
-    if ((has_mfm || hdc_name == QStringLiteral("st506")) && c_mfm > 0) {
+    if ((has_mfm || hdc_name.left(5) == QStringLiteral("st506")) && c_mfm > 0) {
         d->hdds[HDD_BUS_MFM].label = std::make_unique<QLabel>();
         d->hdds[HDD_BUS_MFM].setActive(false);
         d->hdds[HDD_BUS_MFM].label->setToolTip(QStringLiteral("Hard Disk (%1)").arg("MFM/RLL"));
         sbar->addWidget(d->hdds[HDD_BUS_MFM].label.get());
     }
-    if ((has_esdi || hdc_name == QStringLiteral("esdi")) && c_esdi > 0) {
+    if ((has_esdi || hdc_name.left(4) == QStringLiteral("esdi")) && c_esdi > 0) {
         d->hdds[HDD_BUS_ESDI].label = std::make_unique<QLabel>();
         d->hdds[HDD_BUS_ESDI].setActive(false);
         d->hdds[HDD_BUS_ESDI].label->setToolTip(QStringLiteral("Hard Disk (%1)").arg("ESDI"));
         sbar->addWidget(d->hdds[HDD_BUS_ESDI].label.get());
     }
-    if ((has_xta || hdc_name == QStringLiteral("xta")) && c_xta > 0) {
+    if ((has_xta || hdc_name.left(3) == QStringLiteral("xta")) && c_xta > 0) {
         d->hdds[HDD_BUS_XTA].label = std::make_unique<QLabel>();
         d->hdds[HDD_BUS_XTA].setActive(false);
         d->hdds[HDD_BUS_XTA].label->setToolTip(QStringLiteral("Hard Disk (%1)").arg("XTA"));
         sbar->addWidget(d->hdds[HDD_BUS_XTA].label.get());
     }
-    if ((hasIDE() || hdc_name == QStringLiteral("xtide") || hdc_name == QStringLiteral("ide")) && c_ide > 0) {
+    if ((hasIDE() || hdc_name.left(5) == QStringLiteral("xtide") || hdc_name.left(3) == QStringLiteral("ide")) && c_ide > 0) {
         d->hdds[HDD_BUS_IDE].label = std::make_unique<QLabel>();
         d->hdds[HDD_BUS_IDE].setActive(false);
         d->hdds[HDD_BUS_IDE].label->setToolTip(QStringLiteral("Hard Disk (%1)").arg("IDE"));

--- a/src/qt/qt_machinestatus.cpp
+++ b/src/qt/qt_machinestatus.cpp
@@ -28,8 +28,15 @@ extern uint64_t		tsc;
 #include <QLabel>
 #include <QTimer>
 #include <QStatusBar>
+#include <QMenu>
+
+#include "qt_mediamenu.hpp"
+#include "qt_mainwindow.hpp"
+#include "qt_soundgain.hpp"
 
 #include <array>
+
+extern MainWindow* main_window;
 
 namespace {
     struct PixmapSetActive {
@@ -195,7 +202,7 @@ struct MachineStatus::States {
     std::array<StateEmptyActive, MO_NUM> mo;
     std::array<StateActive, HDD_BUS_USB> hdds;
     StateActive net;
-    std::unique_ptr<QLabel> sound;
+    std::unique_ptr<ClickableLabel> sound;
     std::unique_ptr<QLabel> text;
 };
 
@@ -330,8 +337,12 @@ void MachineStatus::refresh(QStatusBar* sbar) {
     sbar->removeWidget(d->sound.get());
 
     if (cassette_enable) {
-        d->cassette.label = std::make_unique<QLabel>();
+        d->cassette.label = std::make_unique<ClickableLabel>();
         d->cassette.setEmpty(QString(cassette_fname).isEmpty());
+        connect((ClickableLabel*)d->cassette.label.get(), &ClickableLabel::clicked, [this](QPoint pos) {
+            MediaMenu::ptr->cassetteMenu->popup(pos);
+        });
+        d->cassette.label->setToolTip(MediaMenu::ptr->cassetteMenu->title());
         sbar->addWidget(d->cassette.label.get());
     }
 
@@ -339,6 +350,10 @@ void MachineStatus::refresh(QStatusBar* sbar) {
         for (int i = 0; i < 2; ++i) {
             d->cartridge[i].label = std::make_unique<QLabel>();
             d->cartridge[i].setEmpty(QString(cart_fns[i]).isEmpty());
+            connect((ClickableLabel*)d->cartridge[i].label.get(), &ClickableLabel::clicked, [this, i](QPoint pos) {
+                MediaMenu::ptr->cartridgeMenus[i]->popup(pos);
+            });
+            d->cartridge[i].label->setToolTip(MediaMenu::ptr->cartridgeMenus[i]->title());
             sbar->addWidget(d->cartridge[i].label.get());
         }
     }
@@ -352,30 +367,46 @@ void MachineStatus::refresh(QStatusBar* sbar) {
         } else {
             d->fdd[i].pixmaps = &d->pixmaps.floppy_35;
         }
-        d->fdd[i].label = std::make_unique<QLabel>();
+        d->fdd[i].label = std::make_unique<ClickableLabel>();
         d->fdd[i].setEmpty(QString(floppyfns[i]).isEmpty());
         d->fdd[i].setActive(false);
+        connect((ClickableLabel*)d->fdd[i].label.get(), &ClickableLabel::clicked, [this, i](QPoint pos) {
+            MediaMenu::ptr->floppyMenus[i]->popup(pos);
+        });
+        d->fdd[i].label->setToolTip(MediaMenu::ptr->floppyMenus[i]->title());
         sbar->addWidget(d->fdd[i].label.get());
     });
 
     iterateCDROM([this, sbar](int i) {
-        d->cdrom[i].label = std::make_unique<QLabel>();
+        d->cdrom[i].label = std::make_unique<ClickableLabel>();
         d->cdrom[i].setEmpty(cdrom[i].host_drive != 200 || QString(cdrom[i].image_path).isEmpty());
         d->cdrom[i].setActive(false);
+        connect((ClickableLabel*)d->cdrom[i].label.get(), &ClickableLabel::clicked, [this, i](QPoint pos) {
+            MediaMenu::ptr->cdromMenus[i]->popup(pos);
+        });
+        d->cdrom[i].label->setToolTip(MediaMenu::ptr->cdromMenus[i]->title());
         sbar->addWidget(d->cdrom[i].label.get());
     });
 
     iterateZIP([this, sbar](int i) {
-        d->zip[i].label = std::make_unique<QLabel>();
+        d->zip[i].label = std::make_unique<ClickableLabel>();
         d->zip[i].setEmpty(QString(zip_drives[i].image_path).isEmpty());
         d->zip[i].setActive(false);
+        connect((ClickableLabel*)d->zip[i].label.get(), &ClickableLabel::clicked, [this, i](QPoint pos) {
+            MediaMenu::ptr->zipMenus[i]->popup(pos);
+        });
+        d->zip[i].label->setToolTip(MediaMenu::ptr->zipMenus[i]->title());
         sbar->addWidget(d->zip[i].label.get());
     });
 
     iterateMO([this, sbar](int i) {
-        d->mo[i].label = std::make_unique<QLabel>();
+        d->mo[i].label = std::make_unique<ClickableLabel>();
         d->mo[i].setEmpty(QString(mo_drives[i].image_path).isEmpty());
         d->mo[i].setActive(false);
+        connect((ClickableLabel*)d->mo[i].label.get(), &ClickableLabel::clicked, [this, i](QPoint pos) {
+            MediaMenu::ptr->moMenus[i]->popup(pos);
+        });
+        d->mo[i].label->setToolTip(MediaMenu::ptr->moMenus[i]->title());
         sbar->addWidget(d->mo[i].label.get());
     });
 
@@ -383,37 +414,49 @@ void MachineStatus::refresh(QStatusBar* sbar) {
     if ((has_mfm || hdc_name == QStringLiteral("st506")) && c_mfm > 0) {
         d->hdds[HDD_BUS_MFM].label = std::make_unique<QLabel>();
         d->hdds[HDD_BUS_MFM].setActive(false);
+        d->hdds[HDD_BUS_MFM].label->setToolTip(QStringLiteral("Hard Disk (%1)").arg("MFM/RLL"));
         sbar->addWidget(d->hdds[HDD_BUS_MFM].label.get());
     }
     if ((has_esdi || hdc_name == QStringLiteral("esdi")) && c_esdi > 0) {
         d->hdds[HDD_BUS_ESDI].label = std::make_unique<QLabel>();
         d->hdds[HDD_BUS_ESDI].setActive(false);
+        d->hdds[HDD_BUS_ESDI].label->setToolTip(QStringLiteral("Hard Disk (%1)").arg("ESDI"));
         sbar->addWidget(d->hdds[HDD_BUS_ESDI].label.get());
     }
     if ((has_xta || hdc_name == QStringLiteral("xta")) && c_xta > 0) {
         d->hdds[HDD_BUS_XTA].label = std::make_unique<QLabel>();
         d->hdds[HDD_BUS_XTA].setActive(false);
+        d->hdds[HDD_BUS_XTA].label->setToolTip(QStringLiteral("Hard Disk (%1)").arg("XTA"));
         sbar->addWidget(d->hdds[HDD_BUS_XTA].label.get());
     }
     if ((hasIDE() || hdc_name == QStringLiteral("xtide") || hdc_name == QStringLiteral("ide")) && c_ide > 0) {
         d->hdds[HDD_BUS_IDE].label = std::make_unique<QLabel>();
         d->hdds[HDD_BUS_IDE].setActive(false);
+        d->hdds[HDD_BUS_IDE].label->setToolTip(QStringLiteral("Hard Disk (%1)").arg("IDE"));
         sbar->addWidget(d->hdds[HDD_BUS_IDE].label.get());
     }
     if ((hasSCSI() || (scsi_card_current[0] != 0) || (scsi_card_current[1] != 0) ||
          (scsi_card_current[2] != 0) || (scsi_card_current[3] != 0)) && c_scsi > 0) {
         d->hdds[HDD_BUS_SCSI].label = std::make_unique<QLabel>();
         d->hdds[HDD_BUS_SCSI].setActive(false);
+        d->hdds[HDD_BUS_SCSI].label->setToolTip(QStringLiteral("Hard Disk (%1)").arg("SCSI"));
         sbar->addWidget(d->hdds[HDD_BUS_SCSI].label.get());
     }
 
     if (do_net) {
         d->net.label = std::make_unique<QLabel>();
         d->net.setActive(false);
+        d->net.label->setToolTip("Network");
         sbar->addWidget(d->net.label.get());
     }
-    d->sound = std::make_unique<QLabel>();
+    d->sound = std::make_unique<ClickableLabel>();
     d->sound->setPixmap(d->pixmaps.sound);
+    // Triggering on click makes the mouse move the window when the button is releases. Do it on button release instead.
+    connect(d->sound.get(), &ClickableLabel::clickedRelease, d->sound.get(), [this](QPoint pos) {
+        SoundGain gain(main_window);
+        gain.exec();
+    });
+    d->sound->setToolTip("Sound");
     sbar->addWidget(d->sound.get());
     d->text = std::make_unique<QLabel>();
     sbar->addWidget(d->text.get());
@@ -489,3 +532,36 @@ void MachineStatus::message(const QString &msg) {
     d->text->setText(msg);
 }
 
+void MachineStatus::updateTip(int tag)
+{
+    int category = tag & 0xfffffff0;
+    int item = tag & 0xf;
+    switch (category) {
+    case SB_CASSETTE:
+        d->cassette.label->setToolTip(MediaMenu::ptr->cassetteMenu->title());
+        break;
+    case SB_CARTRIDGE:
+        d->cartridge[item].label->setToolTip(MediaMenu::ptr->cartridgeMenus[item]->title());
+        break;
+    case SB_FLOPPY:
+        d->fdd[item].label->setToolTip(MediaMenu::ptr->floppyMenus[item]->title());
+        break;
+    case SB_CDROM:
+        d->cdrom[item].label->setToolTip(MediaMenu::ptr->cdromMenus[item]->title());
+        break;
+    case SB_ZIP:
+        d->zip[item].label->setToolTip(MediaMenu::ptr->zipMenus[item]->title());
+        break;
+    case SB_MO:
+        d->mo[item].label->setToolTip(MediaMenu::ptr->moMenus[item]->title());
+        break;
+    case SB_HDD:
+        break;
+    case SB_NETWORK:
+        break;
+    case SB_SOUND:
+        break;
+    case SB_TEXT:
+        break;
+    }
+}

--- a/src/qt/qt_machinestatus.hpp
+++ b/src/qt/qt_machinestatus.hpp
@@ -19,8 +19,8 @@ class ClickableLabel : public QLabel {
         void clickedRelease(QPoint);
 
     protected:
-        void mousePressedEvent(QMouseEvent* event) { emit clicked(event->globalPos()); }
-        void mouseReleasedEvent(QMouseEvent* event) { emit clickedRelease(event->globalPos()); }
+        void mousePressEvent(QMouseEvent* event) override { emit clicked(event->globalPos()); }
+        void mouseReleaseEvent(QMouseEvent* event) override { emit clickedRelease(event->globalPos()); }
 };
 
 class MachineStatus : public QObject

--- a/src/qt/qt_machinestatus.hpp
+++ b/src/qt/qt_machinestatus.hpp
@@ -16,11 +16,11 @@ class ClickableLabel : public QLabel {
 
     signals:
         void clicked(QPoint);
-        void clickedRelease(QPoint);
+        void doubleClicked(QPoint);
 
     protected:
         void mousePressEvent(QMouseEvent* event) override { emit clicked(event->globalPos()); }
-        void mouseReleaseEvent(QMouseEvent* event) override { emit clickedRelease(event->globalPos()); }
+        void mouseDoubleClickEvent(QMouseEvent* event) override { emit doubleClicked(event->globalPos()); }
 };
 
 class MachineStatus : public QObject

--- a/src/qt/qt_machinestatus.hpp
+++ b/src/qt/qt_machinestatus.hpp
@@ -2,8 +2,26 @@
 #define QT_MACHINESTATUS_HPP
 
 #include <QWidget>
+#include <QLabel>
+#include <QMouseEvent>
 
 class QStatusBar;
+
+class ClickableLabel : public QLabel {
+    Q_OBJECT;
+    public:
+        explicit ClickableLabel(QWidget* parent = nullptr)
+        : QLabel(parent) {}
+        ~ClickableLabel() {};
+
+    signals:
+        void clicked(QPoint);
+        void clickedRelease(QPoint);
+
+    protected:
+        void mousePressedEvent(QMouseEvent* event) { emit clicked(event->globalPos()); }
+        void mouseReleasedEvent(QMouseEvent* event) { emit clickedRelease(event->globalPos()); }
+};
 
 class MachineStatus : public QObject
 {
@@ -26,6 +44,7 @@ public slots:
     void setActivity(int tag, bool active);
     void setEmpty(int tag, bool active);
     void message(const QString& msg);
+    void updateTip(int tag);
 
 private:
     struct States;

--- a/src/qt/qt_mainwindow.cpp
+++ b/src/qt/qt_mainwindow.cpp
@@ -49,9 +49,9 @@ MainWindow::MainWindow(QWidget *parent) :
     ui(new Ui::MainWindow)
 {
     Q_INIT_RESOURCE(qt_resources);
-    status = std::make_unique<MachineStatus>(this);
     mm = std::make_shared<MediaMenu>(this);
     MediaMenu::ptr = mm;
+    status = std::make_unique<MachineStatus>(this);
 
     ui->setupUi(this);
     ui->stackedWidget->setMouseTracking(true);
@@ -118,9 +118,10 @@ MainWindow::MainWindow(QWidget *parent) :
     });
 
     connect(this, &MainWindow::updateStatusBarPanes, this, [this] {
-        status->refresh(ui->statusbar);
+        refreshMediaMenu();
     });
     connect(this, &MainWindow::updateStatusBarPanes, this, &MainWindow::refreshMediaMenu);
+    connect(this, &MainWindow::updateStatusBarTip, status.get(), &MachineStatus::updateTip);
     connect(this, &MainWindow::updateStatusBarActivity, status.get(), &MachineStatus::setActivity);
     connect(this, &MainWindow::updateStatusBarEmpty, status.get(), &MachineStatus::setEmpty);
     connect(this, &MainWindow::statusBarMessage, status.get(), &MachineStatus::message);
@@ -920,6 +921,7 @@ bool MainWindow::eventFilter(QObject* receiver, QEvent* event)
 
 void MainWindow::refreshMediaMenu() {
     mm->refresh(ui->menuMedia);
+    status->refresh(ui->statusbar);
 }
 
 void MainWindow::showMessage(const QString& header, const QString& message) {

--- a/src/qt/qt_mainwindow.hpp
+++ b/src/qt/qt_mainwindow.hpp
@@ -37,6 +37,7 @@ signals:
     void updateStatusBarPanes();
     void updateStatusBarActivity(int tag, bool active);
     void updateStatusBarEmpty(int tag, bool empty);
+    void updateStatusBarTip(int tag);
     void updateMenuResizeOptions();
     void updateWindowRememberOption();
 

--- a/src/qt/qt_mediamenu.cpp
+++ b/src/qt/qt_mediamenu.cpp
@@ -63,7 +63,7 @@ void MediaMenu::refresh(QMenu *parentMenu) {
             menu->addSeparator();
             cartridgeEjectPos = menu->children().count();
             menu->addAction("Eject", [this, i]() { cartridgeEject(i); });
-            cartridgeMenus.append(menu);
+            cartridgeMenus[i] = menu;
             cartridgeUpdateMenu(i);
         }
     }
@@ -81,7 +81,7 @@ void MediaMenu::refresh(QMenu *parentMenu) {
         menu->addSeparator();
         floppyEjectPos = menu->children().count();
         menu->addAction("Eject", [this, i]() { floppyEject(i); });
-        floppyMenus.append(menu);
+        floppyMenus[i] = menu;
         floppyUpdateMenu(i);
     });
 
@@ -98,7 +98,7 @@ void MediaMenu::refresh(QMenu *parentMenu) {
         menu->addSeparator();
         cdromImagePos = menu->children().count();
         menu->addAction("Image", [this, i]() { cdromMount(i); })->setCheckable(true);
-        cdromMenus.append(menu);
+        cdromMenus[i] = menu;
         cdromUpdateMenu(i);
     });
 
@@ -114,7 +114,7 @@ void MediaMenu::refresh(QMenu *parentMenu) {
         menu->addAction("Eject", [this, i]() { zipEject(i); });
         zipReloadPos = menu->children().count();
         menu->addAction("Reload previous image", [this, i]() { zipReload(i); });
-        zipMenus.append(menu);
+        zipMenus[i] = menu;
         zipUpdateMenu(i);
     });
 
@@ -130,7 +130,7 @@ void MediaMenu::refresh(QMenu *parentMenu) {
         menu->addAction("Eject", [this, i]() { moEject(i); });
         moReloadPos = menu->children().count();
         menu->addAction("Reload previous image", [this, i]() { moReload(i); });
-        moMenus.append(menu);
+        moMenus[i] = menu;
         moUpdateMenu(i);
     });
 }
@@ -161,8 +161,8 @@ void MediaMenu::cassetteMount(const QString& filename, bool wp) {
     }
 
     ui_sb_update_icon_state(SB_CASSETTE, filename.isEmpty() ? 1 : 0);
-    ui_sb_update_tip(SB_CASSETTE);
     cassetteUpdateMenu();
+    ui_sb_update_tip(SB_CASSETTE);
     config_save();
 }
 
@@ -170,8 +170,8 @@ void MediaMenu::cassetteEject() {
     pc_cas_set_fname(cassette, nullptr);
     memset(cassette_fname, 0, sizeof(cassette_fname));
     ui_sb_update_icon_state(SB_CASSETTE, 1);
-    ui_sb_update_tip(SB_CASSETTE);
     cassetteUpdateMenu();
+    ui_sb_update_tip(SB_CASSETTE);
     config_save();
 }
 
@@ -208,16 +208,16 @@ void MediaMenu::cartridgeSelectImage(int i) {
     cart_load(i, filenameBytes.data());
 
     ui_sb_update_icon_state(SB_CARTRIDGE | i, filename.isEmpty() ? 1 : 0);
-    ui_sb_update_tip(SB_CARTRIDGE | i);
     cartridgeUpdateMenu(i);
+    ui_sb_update_tip(SB_CARTRIDGE | i);
     config_save();
 }
 
 void MediaMenu::cartridgeEject(int i) {
     cart_close(i);
     ui_sb_update_icon_state(SB_CARTRIDGE | i, 1);
-    ui_sb_update_tip(SB_CARTRIDGE | i);
     cartridgeUpdateMenu(i);
+    ui_sb_update_tip(SB_CARTRIDGE | i);
     config_save();
 }
 
@@ -253,16 +253,16 @@ void MediaMenu::floppyMount(int i, const QString &filename, bool wp) {
         fdd_load(i, filenameBytes.data());
     }
     ui_sb_update_icon_state(SB_FLOPPY | i, filename.isEmpty() ? 1 : 0);
-    ui_sb_update_tip(SB_FLOPPY | i);
     floppyUpdateMenu(i);
+    ui_sb_update_tip(SB_FLOPPY | i);
     config_save();
 }
 
 void MediaMenu::floppyEject(int i) {
     fdd_close(i);
     ui_sb_update_icon_state(SB_FLOPPY | i, 1);
-    ui_sb_update_tip(SB_FLOPPY | i);
     floppyUpdateMenu(i);
+    ui_sb_update_tip(SB_FLOPPY | i);
     config_save();
 }
 
@@ -329,19 +329,21 @@ void MediaMenu::cdromMount(int i) {
     } else {
         ui_sb_update_icon_state(SB_CDROM | i, 1);
     }
-    ui_sb_update_tip(SB_CDROM | i);
     cdromUpdateMenu(i);
+    ui_sb_update_tip(SB_CDROM | i);
     config_save();
 }
 
 void MediaMenu::cdromEject(int i) {
     cdrom_eject(i);
     cdromUpdateMenu(i);
+    ui_sb_update_tip(SB_CDROM | i);
 }
 
 void MediaMenu::cdromReload(int i) {
     cdrom_reload(i);
     cdromUpdateMenu(i);
+    ui_sb_update_tip(SB_CDROM | i);
 }
 
 void MediaMenu::cdromUpdateMenu(int i) {
@@ -400,8 +402,8 @@ void MediaMenu::zipMount(int i, const QString &filename, bool wp) {
     }
 
     ui_sb_update_icon_state(SB_ZIP | i, filename.isEmpty() ? 1 : 0);
-    ui_sb_update_tip(SB_ZIP | i);
     zipUpdateMenu(i);
+    ui_sb_update_tip(SB_ZIP | i);
 
     config_save();
 }
@@ -416,8 +418,8 @@ void MediaMenu::zipEject(int i) {
     }
 
     ui_sb_update_icon_state(SB_ZIP | i, 1);
-    ui_sb_update_tip(SB_ZIP | i);
     zipUpdateMenu(i);
+    ui_sb_update_tip(SB_ZIP | i);
     config_save();
 }
 
@@ -431,8 +433,8 @@ void MediaMenu::zipReload(int i) {
         ui_sb_update_icon_state(SB_ZIP|i, 0);
     }
 
-    ui_sb_update_tip(SB_ZIP|i);
     zipUpdateMenu(i);
+    ui_sb_update_tip(SB_ZIP|i);
 
     config_save();
 }
@@ -488,8 +490,8 @@ void MediaMenu::moMount(int i, const QString &filename, bool wp) {
     }
 
     ui_sb_update_icon_state(SB_MO | i, filename.isEmpty() ? 1 : 0);
-    ui_sb_update_tip(SB_MO | i);
     moUpdateMenu(i);
+    ui_sb_update_tip(SB_MO | i);
 
     config_save();
 }
@@ -504,8 +506,8 @@ void MediaMenu::moEject(int i) {
     }
 
     ui_sb_update_icon_state(SB_MO | i, 1);
-    ui_sb_update_tip(SB_MO | i);
     moUpdateMenu(i);
+    ui_sb_update_tip(SB_MO | i);
     config_save();
 }
 
@@ -519,8 +521,8 @@ void MediaMenu::moReload(int i) {
         ui_sb_update_icon_state(SB_MO|i, 0);
     }
 
-    ui_sb_update_tip(SB_MO|i);
     moUpdateMenu(i);
+    ui_sb_update_tip(SB_MO|i);
 
     config_save();
 }

--- a/src/qt/qt_mediamenu.hpp
+++ b/src/qt/qt_mediamenu.hpp
@@ -2,6 +2,7 @@
 
 #include <memory>
 #include <QObject>
+#include <QMap>
 
 class QMenu;
 
@@ -57,11 +58,11 @@ private:
     QWidget* parentWidget = nullptr;
 
     QMenu* cassetteMenu = nullptr;
-    QList<QMenu*> cartridgeMenus;
-    QList<QMenu*> floppyMenus;
-    QList<QMenu*> cdromMenus;
-    QList<QMenu*> zipMenus;
-    QList<QMenu*> moMenus;
+    QMap<int, QMenu*> cartridgeMenus;
+    QMap<int, QMenu*> floppyMenus;
+    QMap<int, QMenu*> cdromMenus;
+    QMap<int, QMenu*> zipMenus;
+    QMap<int, QMenu*> moMenus;
 
     int cassetteRecordPos;
     int cassettePlayPos;
@@ -84,4 +85,6 @@ private:
 
     int moEjectPos;
     int moReloadPos;
+
+    friend class MachineStatus;
 };

--- a/src/qt/qt_ui.cpp
+++ b/src/qt/qt_ui.cpp
@@ -83,7 +83,7 @@ void ui_sb_set_text_w(wchar_t *wstr) {
 
 void
 ui_sb_update_tip(int arg) {
-    qDebug() << Q_FUNC_INFO << arg;
+    main_window->updateStatusBarTip(arg);
 }
 
 void


### PR DESCRIPTION
* Fix crashes on non-continuous floppy/CD-ROM/ZIP/MO media lists
* Status bar icons should now display tooltips and trigger loading menus
* Fix HDDs on certain buses not appearing in status bar